### PR TITLE
Issue: Only variables should be passed by reference

### DIFF
--- a/app/Controller/Component/QimageComponent.php
+++ b/app/Controller/Component/QimageComponent.php
@@ -93,7 +93,9 @@
 			/**
 			* Generate name of the destination file
 			*/
-			$ext = strtolower(end(explode('.', $data['file']['name'])));
+			$filename_array = explode('.', $data['file']['name']);
+			$ext = end($filename_array);
+			$ext = strtolower($ext);
 			$name = uniqid() . date('dmYHis') . '.' . $ext;
 			$complete_path = $data['path'] . $name;
 			
@@ -388,7 +390,9 @@
 		*/
 		private function verifyMime($file){
 			
-			$extension = (end(explode('.', $file)));
+			$filename_array = explode('.',$file);
+
+			$extension = end($filename_array);
 			
 			$extension = strtolower($extension);
 			


### PR DESCRIPTION
Hey. I find a issue in your code. You cannot write end(explode(... )) because end() requires a reference. It modifies the internal representation of the array. See: http://php.net/manual/en/function.end.php
