### PR TITLE
Maintain given width or height from settings if one of those is provided

### DIFF
--- a/app/Controller/Component/QimageComponent.php
+++ b/app/Controller/Component/QimageComponent.php
@@ -242,15 +242,21 @@
 				// If width or height not defined, it's necessary calculate proportional size
 				if (!($width > 0 && $height > 0)){
 					
-					
+					$source_side;
+                    $source_origin;
+                    
 					// Verify if image is horizontal or vertical
 					if ($original_height > $original_width){
-						$height = ($data['width'] > 0) ? $data['width'] : $data['height'];
-						$width  = ($height / $original_height) * $original_width;
+                        $source_side = ($data['width'] > 0) ? $data['width'] : $data['height'];
+                        $source_origin = ($data['width'] > 0) ? $original_width : $original_height;
 					} else {
-						$width = ($data['height'] > 0) ? $data['height'] : $data['width'];
-						$height = ($width / $original_width) * $original_height;
+                        $source_side = ($data['height'] > 0) ? $data['height'] : $data['width'];
+                        $source_origin = ($data['height'] > 0) ? $original_height : $original_width;						
 					}
+                    
+                    $factor = ($source_side / $source_origin);
+                    $height = $factor * $original_height;
+                    $width = $factor * $original_width;
 					
 				} 
 			


### PR DESCRIPTION
In case you provide only one value of width or height, this should not be set as maximum for both sides.
I.e. for a landscape picture: **a given height of 250** and no width will **result in a width of 250** and a smaller height.

Added some lines to keep the given value of
- height -> for landscape
- width -> for portrait

Formatting seems a bit off :/
